### PR TITLE
sbt.ResolveException: unresolved dependency: com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8: not found

### DIFF
--- a/project/play-fork-run.sbt
+++ b/project/play-fork-run.sbt
@@ -1,3 +1,3 @@
 // This plugin adds forked run capabilities to Play projects which is needed for Activator.
 
-addSbtPlugin("com.typesafe.play" % "sbt-fork-run-plugin" % "2.3.8")
+addSbtPlugin("com.typesafe.play" % "sbt-fork-run-plugin" % "2.4.4")


### PR DESCRIPTION
Output from executing `run` in sbt from the slick-3-1 branch:

```
[...]
[info] Resolving com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8 ...
[warn]  module not found: com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8
[warn] ==== typesafe-ivy-releases: tried
[warn]   https://repo.typesafe.com/typesafe/ivy-releases/com.typesafe.play/sbt-fork-run-protocol_2.10/2.3.8/ivys/ivy.xml
[warn] ==== sbt-plugin-releases: tried
[warn]   https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.play/sbt-fork-run-protocol_2.10/2.3.8/ivys/ivy.xml
[warn] ==== local: tried
[warn]   ~/.ivy2/local/com.typesafe.play/sbt-fork-run-protocol_2.10/2.3.8/ivys/ivy.xml
[warn] ==== public: tried
[warn]   https://repo1.maven.org/maven2/com/typesafe/play/sbt-fork-run-protocol_2.10/2.3.8/sbt-fork-run-protocol_2.10-2.3.8.pom
[...]
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8: not found
[warn]  :: com.typesafe.play#routes-compiler_2.10;2.3.8: not found
[warn]  :: com.typesafe.play#sbt-run-support_2.10;2.3.8: not found
[warn]  :: net.contentobjects.jnotify#jnotify;0.94: not found
[warn]  :: com.typesafe#webdriver_2.10;1.0.0: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]      com.typesafe:webdriver_2.10:1.0.0
[warn]        +- com.typesafe.sbt:sbt-webdriver:1.0.0 (scalaVersion=2.10, sbtVersion=0.13)
[warn]        +- com.typesafe.play:sbt-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13)
[warn]        +- com.typesafe.play:sbt-fork-run-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13) (~/git/activator-slick-multidb/project/play-fork-run.sbt#L3-4)
[warn]        +- default:activator-slick-multidb-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
[warn]      com.typesafe.play:routes-compiler_2.10:2.3.8
[warn]        +- com.typesafe.play:sbt-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13)
[warn]        +- com.typesafe.play:sbt-fork-run-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13) (~/git/activator-slick-multidb/project/play-fork-run.sbt#L3-4)
[warn]        +- default:activator-slick-multidb-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
[warn]      net.contentobjects.jnotify:jnotify:0.94
[warn]        +- com.typesafe.play:sbt-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13)
[warn]        +- com.typesafe.play:sbt-fork-run-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13) (~/git/activator-slick-multidb/project/play-fork-run.sbt#L3-4)
[warn]        +- default:activator-slick-multidb-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
[warn]      com.typesafe.play:sbt-fork-run-protocol_2.10:2.3.8
[warn]        +- com.typesafe.play:sbt-fork-run-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13) (~/git/activator-slick-multidb/project/play-fork-run.sbt#L3-4)
[warn]        +- default:activator-slick-multidb-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
[warn]      com.typesafe.play:sbt-run-support_2.10:2.3.8
[warn]        +- com.typesafe.play:sbt-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13)
[warn]        +- com.typesafe.play:sbt-fork-run-plugin:2.3.8 (scalaVersion=2.10, sbtVersion=0.13) (~/git/activator-slick-multidb/project/play-fork-run.sbt#L3-4)
[warn]        +- default:activator-slick-multidb-build:0.1-SNAPSHOT (scalaVersion=2.10, sbtVersion=0.13)
sbt.ResolveException: unresolved dependency: com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8: not found
unresolved dependency: com.typesafe.play#routes-compiler_2.10;2.3.8: not found
unresolved dependency: com.typesafe.play#sbt-run-support_2.10;2.3.8: not found
unresolved dependency: net.contentobjects.jnotify#jnotify;0.94: not found
unresolved dependency: com.typesafe#webdriver_2.10;1.0.0: not found
    at sbt.IvyActions$.sbt$IvyActions$$resolve(IvyActions.scala:294)
    at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:191)
    at sbt.IvyActions$$anonfun$updateEither$1.apply(IvyActions.scala:168)
    at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
    at sbt.IvySbt$Module$$anonfun$withModule$1.apply(Ivy.scala:155)
    at sbt.IvySbt$$anonfun$withIvy$1.apply(Ivy.scala:132)
    at sbt.IvySbt.sbt$IvySbt$$action$1(Ivy.scala:57)
    at sbt.IvySbt$$anon$4.call(Ivy.scala:65)
    at xsbt.boot.Locks$GlobalLock.withChannel$1(Locks.scala:93)
    at xsbt.boot.Locks$GlobalLock.xsbt$boot$Locks$GlobalLock$$withChannelRetries$1(Locks.scala:78)
    at xsbt.boot.Locks$GlobalLock$$anonfun$withFileLock$1.apply(Locks.scala:97)
    at xsbt.boot.Using$.withResource(Using.scala:10)
    at xsbt.boot.Using$.apply(Using.scala:9)
    at xsbt.boot.Locks$GlobalLock.ignoringDeadlockAvoided(Locks.scala:58)
    at xsbt.boot.Locks$GlobalLock.withLock(Locks.scala:48)
    at xsbt.boot.Locks$.apply0(Locks.scala:31)
    at xsbt.boot.Locks$.apply(Locks.scala:28)
    at sbt.IvySbt.withDefaultLogger(Ivy.scala:65)
    at sbt.IvySbt.withIvy(Ivy.scala:127)
    at sbt.IvySbt.withIvy(Ivy.scala:124)
    at sbt.IvySbt$Module.withModule(Ivy.scala:155)
    at sbt.IvyActions$.updateEither(IvyActions.scala:168)
    at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1392)
    at sbt.Classpaths$$anonfun$sbt$Classpaths$$work$1$1.apply(Defaults.scala:1388)
    at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$90.apply(Defaults.scala:1422)
    at sbt.Classpaths$$anonfun$doWork$1$1$$anonfun$90.apply(Defaults.scala:1420)
    at sbt.Tracked$$anonfun$lastOutput$1.apply(Tracked.scala:37)
    at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1425)
    at sbt.Classpaths$$anonfun$doWork$1$1.apply(Defaults.scala:1419)
    at sbt.Tracked$$anonfun$inputChanged$1.apply(Tracked.scala:60)
    at sbt.Classpaths$.cachedUpdate(Defaults.scala:1442)
    at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1371)
    at sbt.Classpaths$$anonfun$updateTask$1.apply(Defaults.scala:1325)
    at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
    at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
    at sbt.std.Transform$$anon$4.work(System.scala:63)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
    at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
    at sbt.Execute.work(Execute.scala:235)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
    at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
    at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
[error] (*:update) sbt.ResolveException: unresolved dependency: com.typesafe.play#sbt-fork-run-protocol_2.10;2.3.8: not found
[error] unresolved dependency: com.typesafe.play#routes-compiler_2.10;2.3.8: not found
[error] unresolved dependency: com.typesafe.play#sbt-run-support_2.10;2.3.8: not found
[error] unresolved dependency: net.contentobjects.jnotify#jnotify;0.94: not found
[error] unresolved dependency: com.typesafe#webdriver_2.10;1.0.0: not found
```

After upgrading to 2.4.0, seems to work fine:

```
> reload
[info] Loading project definition from ~/git/activator-slick-multidb/project
[info] Updating {file:~/git/activator-slick-multidb/project/}activator-slick-multidb-build...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.typesafe.play/sbt-fork-run-plugin/scala_2.10/sbt_0.13/2.4.0/jars/sbt-fork-run-plugin.jar ...
[info]  [SUCCESSFUL ] com.typesafe.play#sbt-fork-run-plugin;2.4.0!sbt-fork-run-plugin.jar (771ms)
[info] downloading https://repo1.maven.org/maven2/com/typesafe/play/sbt-fork-run-protocol_2.10/2.4.0/sbt-fork-run-protocol_2.10-2.4.0.jar ...
[...]
[info] Done updating.
[info] Set current project to slick-multidb (in build file:~/git/activator-slick-multidb/)
> run
[info] Updating {file:~/git/activator-slick-multidb/}activator-slick-multidb...
[info] Resolving jline#jline;2.12.1 ...
[info] downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.7.10/slf4j-nop-1.7.10.jar ...
[info]  [SUCCESSFUL ] org.slf4j#slf4j-nop;1.7.10!slf4j-nop.jar (148ms)
[info] downloading https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.8.7/sqlite-jdbc-3.8.7.jar ...
[info]  [SUCCESSFUL ] org.xerial#sqlite-jdbc;3.8.7!sqlite-jdbc.jar (2077ms)
[info] Done updating.
[info] Compiling 11 Scala sources to ~/git/activator-slick-multidb/target/scala-2.11/classes...
background log: info: Running SimpleExample 
background log: info: - Value for key 'foo': Some(bar)
background log: info: - Value for key 'baz': None
[success] Total time: 36 s, completed Nov 17, 2015 1:43:17 PM
```
